### PR TITLE
Add ambient calculus lecture slides to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Repository to collaborate on [Ambient Calculus](https://en.wikipedia.org/wiki/Am
 
 - [Research Papers](https://github.com/ambientsprotocol/research-ambients/blob/master/ambient-calculus-papers.md) - List of research papers
 - [AmbiIcobjs](https://www-sop.inria.fr/mimosa/ambicobjs/) - Simulation tool for ambient expressions
+- [The Ambient Calculus lecture slides](http://fpl.cs.depaul.edu/jriely/547/extras/ncsm_iii_bertinoro.pdf) - Overview of Ambient Calculus, examples (boolean flags, objective moves, turing machines), encoding π-calculus in ambient calculus, types for ambients.


### PR DESCRIPTION
This PR adds the lecture slides from http://fpl.cs.depaul.edu/jriely/547/extras/ncsm_iii_bertinoro.pdf to the README.